### PR TITLE
Add Registry support for Knative lab

### DIFF
--- a/resources/workshop.yaml
+++ b/resources/workshop.yaml
@@ -34,3 +34,5 @@ spec:
         vendor: octant
       editor:
         enabled: true
+      registry:
+        enabled: true


### PR DESCRIPTION
This would be handy for developers who want to build their own image, including for OSS labs exploring the `func` experience.

(I don't know how this gets synced to https://tanzu.vmware.com/developer/workshops/, but it would be helpful if that could happen, too.)